### PR TITLE
Issue 1: error enabling UTF8 on Server

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+1.1.1 - Bugfix release 2021-05-22
+* Prettier printing of Envelope icon when mail receieved
+* Issue 1: Exception when enabling UTF-8 fixed
+
 1.1
 * With configuration show all or new messages in dropdown menu
 * Implement "Refresh" menu item to update inbox

--- a/imap_counter.py
+++ b/imap_counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env PYTHONIOENCODING=UTF-8 python3
 # <bitbar.title>IMAP Counter</bitbar.title>
-# <bitbar.version>1.1</bitbar.version>
+# <bitbar.version>1.1.1</bitbar.version>
 # <bitbar.author>Jon Lasser</bitbar.author>
 # <bitbar.author.github>disappearinjon</bitbar.author.github>
 # <bitbar.desc>Count unread IMAP messages in inbox</bitbar.desc>
@@ -135,7 +135,10 @@ def startIMAP(config):
         errors.append("login result: {}: {}".format(ok, result))
 
     # Enable the UTF-8 capability, but ignore any errors
-    imap.enable(UTF8CAP)
+    try:
+        imap.enable(UTF8CAP)
+    except imaplib.error:
+        pass
 
     return imap, errors
 
@@ -234,9 +237,9 @@ def printHeader(config, mailCount):
     if mailCount == 0:
         print(':envelope:')
     else:
-        print(':envelope: {} | color={},{}'.format(mailCount,
-                                                   config[UNREAD_LIGHT],
-                                                   config[UNREAD_DARK]))
+        print(':envelope.fill: {} | color={},{}'.format(mailCount,
+                                                        config[UNREAD_LIGHT],
+                                                        config[UNREAD_DARK]))
     print('---')
     return
 


### PR DESCRIPTION
Fixes an issue where enabling UTF8 can trigger an exception when the server does not support this command.
Thanks to Patrick (uselpa) for reporting this issue.

Also minor improvement for envelope icon display.

